### PR TITLE
Update NodeJS to version 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     default: 0.6.4
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
Updating to NodeJS 16 as we get this warning when running the action:
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: andersy005/gh-action-py-liccheck@main
```